### PR TITLE
Support labeled link (e.g. L<foobar|http://example.com>)

### DIFF
--- a/lib/Pod/To/Markdown.pm6
+++ b/lib/Pod/To/Markdown.pm6
@@ -169,8 +169,13 @@ multi sub pod2markdown(Pod::FormattingCode $pod) is export {
     # It is safer to strip formatting in code blocks
     return $text if $in-code-block;
 
-    $text = '[' ~ $text ~ '](' ~ $text ~ ')'
-        if $pod.type eq 'L';
+    if $pod.type eq 'L' {
+        if $pod.meta.elems > 0 {
+            $text =  '[' ~ $text ~ '](' ~ $pod.meta[0] ~ ')';
+        } else {
+            $text = '[' ~ $text ~ '](' ~ $text ~ ')';
+        }
+    }
 
     $text = %Mformats{$pod.type} ~ $text ~ %Mformats{$pod.type}
         if %Mformats.EXISTS-KEY: $pod.type;

--- a/t/formatted.t
+++ b/t/formatted.t
@@ -17,7 +17,9 @@ This text is <var>to be replaced</var>.
 
 This text is invisible.
 
-This text contains a link to [http://www.google.com/](http://www.google.com/).};
+This text contains a link to [http://www.google.com/](http://www.google.com/).
+
+This text contains a link with label to [google](http://www.google.com/).};
 
 is pod2markdown($=pod).trim, $markdown.trim,
     'Decodes formatted text correctly';
@@ -36,4 +38,6 @@ This text is R<to be replaced>.
 This text is Z<blabla>invisible.
 
 This text contains a link to L<http://www.google.com/>.
+
+This text contains a link with label to L<google|http://www.google.com/>.
 =end pod


### PR DESCRIPTION
`L<foobar|http://example.com>` should be `[foobar](http://example.com)` but it is different now.
So I fix it.