### PR TITLE
fix test for Perl 6.c

### DIFF
--- a/t/definition.t
+++ b/t/definition.t
@@ -15,7 +15,7 @@ asdf1
 ```
 sub asdf(
     Str $asdf1, 
-    Str :$asdf2 = { ... }
+    Str :$asdf2 = "asdf"
 ) returns Str
 ```
 
@@ -34,7 +34,7 @@ t
 
 ```
 method asdf(
-    Str :$asdf = { ... }
+    Str :$asdf = "asdf"
 ) returns Str
 ```
 


### PR DESCRIPTION
To pass on latest rakudo
% perl6 -v
This is Rakudo version 2016.02-98-gc7be33a built on MoarVM version 2016.02-8-ga329e2d
implementing Perl 6.c.