### PR TITLE
Use SPDX identifier in license field of META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,6 +1,7 @@
 {
   "perl"        : "6.*",
   "name"        : "Pod::To::Markdown",
+  "license"     : "Artistic-2.0",
   "version"     : "v0.0.1",
   "description" : "Render Perl6 Pod as Markdown",
   "author"      : "Jorn van Engelen",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license