### PR TITLE
Have :no-fenced-codeblocks argument work for signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# v0.1.1
+* Add support for properly escaping  backticks inside `C<code tags>`
+
+# v0.1.0
+* Add support for :no-fenced-codeblocks argument inside of sub and method signatures
+* Add support for nested bullet points
+* Use ```` ```lang```` for code blocks if lang is set in the config of the code block
+```perl6
+=begin code :lang<perl6
+foo
+=end code
+```
+Will result in:
+````
+```perl6
+foo
+```
+````
+* Various bugfixes related to rakudo changes

--- a/META6.json
+++ b/META6.json
@@ -2,7 +2,7 @@
   "perl"        : "6.*",
   "name"        : "Pod::To::Markdown",
   "license"     : "Artistic-2.0",
-  "version"     : "v0.0.1",
+  "version"     : "v0.1.0",
   "description" : "Render Perl6 Pod as Markdown",
   "author"      : "Jorn van Engelen",
   "depends"     : [ ],

--- a/META6.json
+++ b/META6.json
@@ -2,7 +2,7 @@
   "perl"        : "6.*",
   "name"        : "Pod::To::Markdown",
   "license"     : "Artistic-2.0",
-  "version"     : "v0.1.0",
+  "version"     : "v0.1.1",
   "description" : "Render Perl6 Pod as Markdown",
   "authors"     : [ "Jorn van Engelen" ],
   "depends"     : [ ],

--- a/META6.json
+++ b/META6.json
@@ -4,7 +4,7 @@
   "license"     : "Artistic-2.0",
   "version"     : "v0.1.0",
   "description" : "Render Perl6 Pod as Markdown",
-  "author"      : "Jorn van Engelen",
+  "authors"     : [ "Jorn van Engelen" ],
   "depends"     : [ ],
   "provides"    : {
     "Pod::To::Markdown"     : "lib/Pod/To/Markdown.pm6"

--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 # Pod::To::Markdown (Perl6)
 
-[![Build Status](https://travis-ci.org/softmoth/perl6-pod-to-markdown.svg?branch=master)](https://travis-ci.org/softmoth/perl6-pod-to-markdown)
-
-Render Pod as Markdown.
+[![Build Status](https://travis-ci.org/softmoth/perl6-pod-to-markdown.svg?branch=master)](https://travis-ci.org/softmoth/perl6-pod-to-markdo
+wn)
 
 ## Installation
+
+Using zef (preferred)
+```
+$ zef update
+$ zef install Pod::To::Markdown
+```
 
 Using panda:
 ```
@@ -12,23 +17,21 @@ $ panda update
 $ panda install Pod::To::Markdown
 ```
 
-Using ufo:
-```
-$ ufo
-$ make
-$ make test
-$ make install
-```
+NAME
+====
 
-## Usage:
+Pod::To::Markdown - Render Pod as Markdown
+
+SYNOPSIS
+========
 
 From command line:
 
-    $ perl6 --doc=Markdown lib/class.pm
+    $ perl6 --doc=Markdown lib/to/class.pm
 
 From Perl6:
 
-```
+```perl6
 use Pod::To::Markdown;
 
 =NAME
@@ -36,6 +39,30 @@ foobar.pl
 
 =SYNOPSIS
     foobar.pl <options> files ...
-	
+
 say pod2markdown($=pod);
 ```
+
+To render without fenced codeblocks ```` ``` ````, as some markdown engines don't support this, use the :no-fenced-codeblocks option. If you want to have code show up as ```` ```perl6```` to enable syntax highlighting on certain markdown renderers, use: `=begin code :lang<perl6>`
+
+EXPORTS
+=======
+
+    class Pod::To::Markdown;
+    sub pod2markdown; # See below
+
+DESCRIPTION
+===========
+
+
+
+### sub pod2markdown
+
+```
+sub pod2markdown(
+    Pod::Heading $pod,
+    Bool :$no-fenced-codeblocks
+) returns Mu
+```
+
+Render Pod as Markdown

--- a/lib/Pod/To/Markdown.pm6
+++ b/lib/Pod/To/Markdown.pm6
@@ -108,7 +108,9 @@ multi sub pod2markdown(Pod::Block::Declarator $pod, Bool :$no-fenced-codeblocks)
                @params.pop if @params[*-1].name eq '%_';
 	    my $name = $_.name;
 	    $ret ~= head2markdown($lvl+1, "method $name") ~ "\n\n";
-	    $ret ~= "```\nmethod $name" ~ signature2markdown(@params) ~ "$returns\n```";
+	    $ret ~= $no-fenced-codeblocks
+            ?? ("method $name" ~ signature2markdown(@params) ~ "$returns").indent(4)
+            !! "```\nmethod $name" ~ signature2markdown(@params) ~ "$returns\n```";
         }
         when Sub {
 	    my $returns = ($_.signature.returns.WHICH.perl eq 'Mu')
@@ -117,7 +119,9 @@ multi sub pod2markdown(Pod::Block::Declarator $pod, Bool :$no-fenced-codeblocks)
 	    my @params = $_.signature.params;
 	    my $name = $_.name;
 	    $ret ~= head2markdown($lvl+1, "sub $name") ~ "\n\n";
-	    $ret ~= "```\nsub $name" ~ signature2markdown(@params) ~ "$returns\n```";
+	    $ret ~= $no-fenced-codeblocks
+            ?? ("sub $name" ~ signature2markdown(@params) ~ "$returns").indent(4)
+            !! "```\nsub $name" ~ signature2markdown(@params) ~ "$returns\n```";
         }
         when .HOW ~~ Metamodel::ClassHOW {
 	    if ($_.WHAT.perl eq 'Attribute') {

--- a/lib/Pod/To/Markdown.pm6
+++ b/lib/Pod/To/Markdown.pm6
@@ -7,7 +7,7 @@ From command line:
     $ perl6 --doc=Markdown lib/to/class.pm
 
 From Perl6:
-=begin code
+=begin code :lang<perl6>
 use Pod::To::Markdown;
 
 =NAME
@@ -18,6 +18,11 @@ foobar.pl
 
 say pod2markdown($=pod);
 =end code
+To render without fenced codeblocks C<```>, as some markdown engines don't support
+this, use the :no-fenced-codeblocks option.
+If you want to have code show up as C<```perl6> to enable syntax highlighting on
+certain markdown renderers, use:
+C<=begin code :lang<perl6>>
 =end SYNOPSIS
 
 =begin EXPORTS

--- a/t/definition.t
+++ b/t/definition.t
@@ -3,7 +3,7 @@ use lib 'lib';
 
 use Test;
 use Pod::To::Markdown;
-plan 1;
+plan 2;
 
 my $markdown = q{module Asdf1
 ------------
@@ -40,8 +40,42 @@ method asdf(
 
 Method asdf2};
 
+my $markdown-no-fenced = q{module Asdf1
+------------
+
+asdf1
+
+### sub asdf
+
+    sub asdf(
+        Str $asdf1, 
+        Str :$asdf2 = "asdf"
+    ) returns Str
+
+Sub asdf1
+
+class Asdf2
+-----------
+
+Asdf2
+
+### has Str $.t
+
+t
+
+### method asdf
+
+    method asdf(
+        Str :$asdf = "asdf"
+    ) returns Str
+
+Method asdf2};
+
 is pod2markdown($=pod).trim, $markdown.trim,
     'Converts definitions to Markdown correctly';
+
+is pod2markdown($=pod, :no-fenced-codeblocks).trim, $markdown-no-fenced.trim,
+    'Converts definitions to Markdown correctly without fenced codeblocks';
 
 #| asdf1
 module Asdf1 {

--- a/t/formatted_escaping.t
+++ b/t/formatted_escaping.t
@@ -1,0 +1,26 @@
+use v6;
+use lib <blib/lib lib>;
+
+use Test;
+use Pod::To::Markdown;
+plan 1;
+
+my $markdown = Q:to/ENDing/;
+Here is a single backtick `` ` ``.
+
+Here is two backticks ``` `` ```.
+
+Here is one ```` ```perl6```` with three.
+ENDing
+
+is pod2markdown($=pod).trim, $markdown.chomp,
+    'Properly deals with code that contains backticks in it';
+
+=begin pod
+Here is a single backtick C<`>.
+
+Here is two backticks C<``>.
+
+Here is one C<```perl6> with three.
+
+=end pod


### PR DESCRIPTION
* If we have the :no-fenced-codeblocks argument, don't use ```...``` fenced
blocks when making sub and method signatures.
* Add tests for :no-fenced-codeblocks for signatures
* Bump the version from v0.0.1 to v0.1.0