### PR TITLE
Ignore =over / =back directives

### DIFF
--- a/lib/Pod/To/Markdown.pm6
+++ b/lib/Pod/To/Markdown.pm6
@@ -95,6 +95,8 @@ multi sub node2md(Pod::Block::Named $pod) {
         when 'defn'   { node2md($pod.contents) }
         when 'config' { Debug { die "NAMED CONFIG" }; '' }
         when 'nested' { Debug { die "NAMED NESTED" }; '' }
+        when 'over'   { Debug { die "OVER DIRECTIVE" }; '' }
+        when 'back'   { Debug { die "BACK DIRECTIVE" }; '' }
         default       { head2md(1, $pod.name) ~ "\n\n" ~ node2md($pod.contents); }
     }
 }

--- a/t/over.t
+++ b/t/over.t
@@ -1,0 +1,33 @@
+use v6;
+
+# We just ignore over/back directives (Markdown has limited support for
+# this)
+
+use Test;
+use Pod::To::Markdown;
+
+plan 1;
+
+=begin pod
+=over 4
+
+asdf
+
+Foo
+
+=back 4
+
+asdf
+
+=end pod
+
+
+is pod2markdown($=pod), q:to/EOF/, 'Ignore =over/=back';
+asdf
+
+Foo
+
+asdf
+EOF
+
+# vim:set ft=perl6:


### PR DESCRIPTION
=over / =back were displaying as if they were headings, with the =over number being a heading.

I.E. =over 4 becomes:

over
====

4

And =back becomes:

back
====

This just ignores both directives for lack of a clear better thing to do.  I did wrap the in Debug calls like the Config and other directives.  Let me know if you have a different preference.