### PR TITLE
depends Pod::To::HTML:auth<github:Raku>

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -6,7 +6,7 @@
   "description" : "Render Perl6 Pod as Markdown",
   "authors"     : [ "Jorn van Engelen" ],
   "depends"     : [
-      "Pod::To::HTML"
+      "Pod::To::HTML:auth<github:Raku>"
   ],
   "provides"    : {
     "Pod::To::Markdown": "lib/Pod/To/Markdown.pm6"

--- a/lib/Pod/To/Markdown.pm6
+++ b/lib/Pod/To/Markdown.pm6
@@ -41,7 +41,7 @@ sub MAIN() {
 
 unit class Pod::To::Markdown;
 
-use Pod::To::HTML;
+use Pod::To::HTML:auth<github:Raku>;
 
 #my sub Debug(&code) { &code() }
 my sub Debug(&code) { }


### PR DESCRIPTION
At the time of writing (2020-07-20), there are more than 1 Pod::To::HTML module:

```
❯ zef search  Pod::To::HTML
===> Found 5 results
-----------------------------------------------------------------------------------------------------------------------
ID|From                             |Package                                             |Description
-----------------------------------------------------------------------------------------------------------------------
0 |Zef::Repository::Ecosystems<p6c> |PodCache::Module:ver<0.3.1>:auth<Richard Hainsworth>|Render pod files from a ca...
1 |Zef::Repository::Ecosystems<p6c> |Raku::Pod::Render:ver<2.3.1>:auth<github:finanalyst>|A generic Pod Renderer for ..
2 |Zef::Repository::Ecosystems<p6c> |Pod::To::HTML:ver<0.7.0>:auth<github:Raku>          |Convert Raku Pod to HTML
3 |Zef::Repository::Ecosystems<cpan>|Pod::To::HTML::Section:ver<0.1.0>:api<0>            |Convert a Pod6 document to ..
4 |Zef::Repository::Ecosystems<cpan>|Pod::To::HTMLBody:ver<0.0.1>:auth<github:drforr>    |HTML body
-----------------------------------------------------------------------------------------------------------------------
````

And the first candidate of `Pod::To::HTML` for zef is `Pod::To::HTML:auth<github:finanalyst>`.

I think perl6-pod-to-markdown expects `Pod::To::HTML:auth<github:Raku>`.
So this PR changes `Pod::To::HTML` to `Pod::To::HTML:auth<github:Raku>`.

This PR will also close #20 .