### PR TITLE
Fix rendering of role-extended Attributes

### DIFF
--- a/lib/Pod/To/Markdown.rakumod
+++ b/lib/Pod/To/Markdown.rakumod
@@ -77,15 +77,13 @@ multi sub node2md(Pod::Block::Declarator $pod) {
         when Sub {
             signature2md($lvl, $_, :!method);
         }
+        when Attribute {
+            my $name = .gist;
+            $name .= subst('!', '.') if .has_accessor;
+            head2md($lvl+1, "has $name");
+        }
         when .HOW ~~ Metamodel::ClassHOW {
-            if (.WHAT =:= Attribute) {
-                my $name = .gist;
-                $name .= subst('!', '.') if .has_accessor;
-                head2md($lvl+1, "has $name");
-            }
-            else {
-                head2md($lvl, "class $_.perl()");
-            }
+            head2md($lvl, "class $_.perl()");
         }
         when .HOW ~~ Metamodel::ModuleHOW {
             head2md($lvl, "module $_.perl()");


### PR DESCRIPTION
The test for an declarator Attribute was too precise and wasn't matching if
the Attribute had extra roles applied to it.

Fixed by a small restructuring to make it the same as Rakudo's latest
built-in Pod::To::Text handling of declarators.

closes #28.